### PR TITLE
ヌシ、負けイベ敵、ケントの戦闘データを定義

### DIFF
--- a/Assets/Scripts/Battle/Data/Enemies/EnemyData_602.asset
+++ b/Assets/Scripts/Battle/Data/Enemies/EnemyData_602.asset
@@ -14,17 +14,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   enemyId: 602
   enemyName: "\u30B1\u30F3\u30C8"
-  sprite: {fileID: 0}
-  HP: 0
-  MP: 0
+  sprite: {fileID: 21300000, guid: da481a0459cffbc43a121be50bf5be5f, type: 3}
+  HP: 150
+  MP: 50
   Attack: 75
-  Defence: 65
-  MagicAttack: 58
-  MagicDefence: 60
-  Speed: 45
+  Defence: 50
+  MagicAttack: 75
+  MagicDefence: 50
+  Speed: 100
   Evasion: 0
-  exp: 350
-  gold: 100
+  exp: 500
+  gold: 1000
   enemyActionRecords:
   - enemyActionCategory: 0
     enemyConditionRecords: []

--- a/Assets/Scripts/Battle/Data/Enemies/EnemyData_605.asset
+++ b/Assets/Scripts/Battle/Data/Enemies/EnemyData_605.asset
@@ -15,13 +15,13 @@ MonoBehaviour:
   enemyId: 605
   enemyName: "\u30CC\u30B7"
   sprite: {fileID: 6022851953799518874, guid: 8eef3e8b93e6170478bab6a88c20d708, type: 3}
-  HP: 1000
-  MP: 100
+  HP: 20
+  MP: 50
   Attack: 10
-  Defence: 10
+  Defence: 2
   MagicAttack: 10
-  MagicDefence: 10
-  Speed: 10
+  MagicDefence: 2
+  Speed: 50
   Evasion: 0
   exp: 70
   gold: 100

--- a/Assets/Scripts/Battle/Data/Enemies/EnemyData_606.asset
+++ b/Assets/Scripts/Battle/Data/Enemies/EnemyData_606.asset
@@ -14,14 +14,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   enemyId: 606
   enemyName: "\u3059\u3054\u304F\u5F37\u305D\u3046\u306A\u6575"
-  sprite: {fileID: 0}
+  sprite: {fileID: 5160158408096751521, guid: 6e484dfd1015a4549b03023dd30ed27c, type: 3}
   HP: 10000
   MP: 999
   Attack: 999
   Defence: 999
   MagicAttack: 999
   MagicDefence: 999
-  Speed: 999
+  Speed: 1
   Evasion: 999
   exp: 0
   gold: 0


### PR DESCRIPTION
森までのイベント敵のステータスを更新しました。