### PR TITLE
タイトルから遷移して、すぐにアニメーションが再生されるイベントを起こすように、移動先を指定

### DIFF
--- a/Assets/Scripts/ScriptEngine/ObjectEngine.cs
+++ b/Assets/Scripts/ScriptEngine/ObjectEngine.cs
@@ -20,7 +20,7 @@ public class ObjectEngine : MonoBehaviour
 
     [SerializeField] private MapEngine mapEngine;
     [SerializeField] private MapDataController mapDataController;
-    private static Vector2Int changedPos = new Vector2Int(10, 4);
+    private static Vector2Int changedPos = new Vector2Int(12, 4);
     private string _mapName;
     private Vector2Int _pastGridPosition = new Vector2Int(-1, -1);
     private bool conversationFlag = false;


### PR DESCRIPTION
タイトルから最初のマップに遷移する際、アニメーションが始まるイベントを踏むように調整しました。